### PR TITLE
Operation with unevaluated n_call

### DIFF
--- a/R/TextReuseTextDocument.R
+++ b/R/TextReuseTextDocument.R
@@ -88,7 +88,7 @@ TextReuseTextDocument <- function(text, file = NULL, meta = list(),
     n_call <- match.call(expand.dots = TRUE)[["n"]]
     if (is.null(n_call))
       n_call <- 3
-    if (wordcount(text) < n_call + 1) {
+    if (wordcount(text) < eval(n_call) + 1) {
       warning("Skipping document with ID '", document_id,
               "' because it has too few words ",
               "to create at least two n-grams with n = ", n_call, ".",

--- a/R/TextReuseTextDocument.R
+++ b/R/TextReuseTextDocument.R
@@ -88,7 +88,7 @@ TextReuseTextDocument <- function(text, file = NULL, meta = list(),
     n_call <- match.call(expand.dots = TRUE)[["n"]]
     if (is.null(n_call))
       n_call <- 3
-    if (wordcount(text) < eval(n_call) + 1) {
+    if (wordcount(text) < eval(n_call, parent.frame()) + 1) {
       warning("Skipping document with ID '", document_id,
               "' because it has too few words ",
               "to create at least two n-grams with n = ", n_call, ".",

--- a/tests/testthat/test-TextReuseTextDocument.R
+++ b/tests/testthat/test-TextReuseTextDocument.R
@@ -89,3 +89,10 @@ test_that("gives warning when skipping short documents from file", {
   expect_null(short_doc)
   file.remove(too_short)
 })
+
+test_that("number of words input can be a variable", {
+  i <- 1
+  expect_error(TextReuseTextDocument(file = "newman.txt",
+                                     tokenizer = tokenize_ngrams,
+                                     n = i), NA)
+})


### PR DESCRIPTION
When iterating on the number of words in each n-gram, I discovered that `TextReuseTextDocument` returns an error when `n` is a variable:
```
 Error in n_call + 1 : non-numeric argument to binary operator 
```
This solves the bug. I also added a quick test.