### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ vignette](https://cran.r-project.org/package=textreuse/vignettes/textreuse-minha
 
 ### Text alignment
 
-We can also extract the optimal alignment between to documents with a
+We can also extract the optimal alignment between two documents with a
 version of the
 [Smith-Waterman](https://en.wikipedia.org/wiki/Smith-Waterman_algorithm)
 algorithm, used for protein sequence alignment, adapted for natural


### PR DESCRIPTION
Same as https://github.com/ropensci/textreuse/pull/98 :
Typo with incorrect meaning (to/two)
I am unsure why there is README.Rmd and README.md